### PR TITLE
Neither Amazon AWS nor eBay yet support FIDO U2F.

### DIFF
--- a/_data/devices/cloud.yml
+++ b/_data/devices/cloud.yml
@@ -4,7 +4,7 @@ websites:
       img: aws.png
       tfa: Yes
       otp: Yes
-      u2f: Yes
+      u2f: No
       doc: http://aws.amazon.com/iam/details/mfa/
 
     - name: appFog

--- a/_data/devices/retail.yml
+++ b/_data/devices/retail.yml
@@ -24,7 +24,7 @@ websites:
       url: http://ebay.com
       img: ebay.png
       tfa: Yes
-      u2f: Yes
+      u2f: No
       otp: Yes
       exceptions:
           text: "While PayPal supports hardware and software 2FA in all locales, eBay only supports 2FA in some locales."


### PR DESCRIPTION
Fix for the database.

As of 2015-01-08, neither Amazon AWS nor eBay support FIDO U2F.
