### PR TITLE
fix DigiFlak link

### DIFF
--- a/_data/devices/providers.yml
+++ b/_data/devices/providers.yml
@@ -79,7 +79,7 @@ providers:
 #    u2f: Yes
 
   - name: DigiFlak
-    url: https://www.digiflak.com
+    url: http://www.digiflak.com
     img: digiflak.png
     hardware: Yes
     u2f: Yes


### PR DESCRIPTION
Fix link, https version of site doens't work.
