### PR TITLE
backup.yml: Dropbox now supports U2F!

### DIFF
--- a/_data/devices/backup.yml
+++ b/_data/devices/backup.yml
@@ -47,6 +47,7 @@ websites:
     img: dropbox.png
     tfa: Yes
     otp: Yes
+    u2f: Yes
     doc: https://www.dropbox.com/help/363/en
 
   - name: Evernote


### PR DESCRIPTION
This change updates the entry for Dropbox to reflect their recently added support for U2F tokens.

https://www.dropbox.com/en/help/363#2fa-security-keys
