### PR TITLE
Github have added U2F support

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -49,6 +49,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://help.github.com/articles/about-two-factor-authentication
 
     - name: Infobip


### PR DESCRIPTION
Announced today at Github Universe, Github have U2F support.  Confirmed using (conference-supplied) YubiKey Edge.
