### PR TITLE
Bitbucket supports two-factor auth

### DIFF
--- a/_data/devices/developer.yml
+++ b/_data/devices/developer.yml
@@ -23,7 +23,8 @@ websites:
       url: https://bitbucket.org
       twitter: bitbucket
       img: bitbucket.png
-      tfa: No
+      tfa: Yes
+      doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Code Climate
       url: https://codeclimate.com


### PR DESCRIPTION
While we don't yet have U2F or OTP support, we do support two-factor authentication. I've set the yml file appropriately and included a link to our documentation.
