### PR TITLE
Update Wordpress doc site

### DIFF
--- a/_data/devices/social.yml
+++ b/_data/devices/social.yml
@@ -108,7 +108,7 @@ websites:
       tfa: Yes
       otp: Yes
       u2f: Yes
-      doc: https://github.com/Yubico/wordpress-u2f
+      doc: https://github.com/georgestephanis/two-factor
 
     - name: WordPress.com
       url: https://wordpress.com


### PR DESCRIPTION
The current project link for Wordpress support is discontinued (as
stated by its readme). It directs users to another discontinued project
(https://github.com/shield-9/u2f-login), which links to a currently
maintained plugin.
