### PR TITLE
PayPal: SMS-based auth is available in the UK

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -50,7 +50,7 @@ websites:
       software: Yes
       hardware: No
       exceptions:
-          text: "2FA only available in the US and Canada. SMS only available in the US. Hardware-based 2FA is no longer available."
+          text: "2FA only available in the US and Canada. SMS only available in the US and UK. Hardware-based 2FA is no longer available."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Skrill


### PR DESCRIPTION
I don't know whether it is also available in other countries, but I use it here in the UK.

I can see references to hardware auth tokens in the settings page, but no way to obtain one, so I think that part is still true.

The link to their documentation is dead, but I can't find a good replacement.
