### PR TITLE
Fix Nitrokey/dongleauth#39

### DIFF
--- a/_data/devices/remote.yml
+++ b/_data/devices/remote.yml
@@ -30,6 +30,6 @@ websites:
       img: openssh.png
       tfa: Yes
       otp: Yes
-      u2f: Yes
-      doc: https://github.com/bluecmd/openssh-u2f
+      u2f: No
+      status: https://bugzilla.mindrot.org/show_bug.cgi?id=2319
 


### PR DESCRIPTION
OpenSSH currently doesn't support U2F.

At best, there are patches floating around. AFAICS pstream hasn't
announced that they are actively working on adding U2F support.
