### PR TITLE
Remove Cryptsy scam site

### DIFF
--- a/_data/bitcoin.yml
+++ b/_data/bitcoin.yml
@@ -129,13 +129,6 @@ websites:
       software: Yes
       doc: https://www.coinsetter.com/my/security
 
-    - name: Cryptsy
-      url: https://cryptsy.com/
-      img: cryptsy.png
-      tfa: Yes
-      software: Yes
-      doc: https://www.cryptsy.com/pages/security
-
     - name: Eclipse Mining Consortium
       url: https://eclipsemc.com
       img: eclipsemc.png


### PR DESCRIPTION
Cryptsy was a scam exchange that Big Vern from Florida ran for a while. He has since shut the site down after stealing money from its users. Big Vern now lives in China with his mistress.