### PR TITLE
Add support for external link on exceptions

### DIFF
--- a/_data/devices/backup.yml
+++ b/_data/devices/backup.yml
@@ -71,6 +71,7 @@ websites:
     u2f: Yes
     exceptions:
         text: "Google Chrome browser required for U2F."
+        link: https://support.google.com/accounts/answer/6103523
     doc: http://www.google.com/intl/en-US/landing/2step/features.html
 
   - name: iCloud

--- a/_data/devices/cloud.yml
+++ b/_data/devices/cloud.yml
@@ -45,6 +45,7 @@ websites:
       u2f: Yes
       exceptions:
           text: "Google Chrome browser required for U2F."
+          link: https://support.google.com/accounts/answer/6103523
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Heroku

--- a/_data/devices/communication.yml
+++ b/_data/devices/communication.yml
@@ -39,6 +39,7 @@ websites:
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
       exceptions:
           text: "Google Chrome browser required for U2F."
+          link: https://support.google.com/accounts/answer/6103523
 
     - name: HipChat
       url: https://www.hipchat.com

--- a/_data/devices/developer.yml
+++ b/_data/devices/developer.yml
@@ -28,6 +28,7 @@ websites:
       u2f: Yes
       exceptions:
           text: "Google Chrome browser required for U2F."
+          link: https://support.google.com/accounts/answer/6103523
       doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Code Climate

--- a/_data/devices/payments.yml
+++ b/_data/devices/payments.yml
@@ -26,6 +26,7 @@ websites:
       u2f: Yes
       exceptions:
           text: "Google Chrome browser required for U2F."
+          link: https://support.google.com/accounts/answer/6103523
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Litle & Co

--- a/_data/devices/social.yml
+++ b/_data/devices/social.yml
@@ -41,6 +41,7 @@ websites:
       u2f: Yes
       exceptions:
           text: "Google Chrome browser required for U2F."
+          link: https://support.google.com/accounts/answer/6103523
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: HootSuite

--- a/_includes/exception.html
+++ b/_includes/exception.html
@@ -19,7 +19,7 @@
 
     {% if include.website.exceptions.link %}
         <a class="popup exception"
-            href="/restrictions#{{ include.website.name | downcase | handle }}"
+            href="{{include.website.exceptions.link}}"
             data-position="bottom center"
             data-html="{{ html | strip_newlines }}">
             <i class="warning red link icon"></i>


### PR DESCRIPTION
The support for external link was _almost_ here, but wasn't used anywhere.
As there is a link explaining the exception for Google products, I thought it worth adding.