### PR TITLE
Facebook adds U2F support

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -34,6 +34,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://www.facebook.com/help/148233965247823
 
     - name: Google+


### PR DESCRIPTION
http://www.wired.co.uk/article/facebook-two-factor-authentication
is one of many news articles confirming the change on 27 Jan 2017

FYI @juanlang