### PR TITLE
Norton account supports U2F

### DIFF
--- a/_data/devices/security.yml
+++ b/_data/devices/security.yml
@@ -29,7 +29,9 @@ websites:
       url: http://us.norton.com
       img: norton.png
       tfa: Yes
-      doc: https://login.norton.com/sso/embedded/learn2fa
+      otp: Yes
+      u2f: Yes
+      doc: https://support.norton.com/sp/en/us/home/current/solutions/v100023155_NortonM_Retail_1_en_us
 
     - name: OpenDNS
       url: http://www.opendns.com/

--- a/_data/devices/security.yml
+++ b/_data/devices/security.yml
@@ -29,7 +29,6 @@ websites:
       url: http://us.norton.com
       img: norton.png
       tfa: Yes
-      otp: Yes
       u2f: Yes
       doc: https://support.norton.com/sp/en/us/home/current/solutions/v100023155_NortonM_Retail_1_en_us
 

--- a/_data/security.yml
+++ b/_data/security.yml
@@ -105,6 +105,7 @@ websites:
       software: Yes
       sms: Yes
       phone: Yes
+      hardware: Yes
       doc: https://login.norton.com/sso/embedded/learn2fa
 
     - name: OpenDNS


### PR DESCRIPTION
Norton account now supports U2F keys. This is different than [Yubikey VIP](https://www.yubico.com/why-yubico/for-business/authentication-solutions/symantec/), normal u2f only Yubikey works too.