### PR TITLE
Bitbucket now also works with Firefox

### DIFF
--- a/_data/devices/developer.yml
+++ b/_data/devices/developer.yml
@@ -26,9 +26,6 @@ websites:
       tfa: Yes
       otp: Yes
       u2f: Yes
-      exceptions:
-          text: "Google Chrome browser required for U2F."
-          link: https://support.google.com/accounts/answer/6103523
       doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Code Climate


### PR DESCRIPTION
I can confirm that now the u2f of Bitbucket also works with Firefox.