### PR TITLE
Bitbay.net no longer supports Fido U2F

### DIFF
--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -9,10 +9,9 @@ websites:
     - name: BitBay
       url: https://bitbay.net/
       img: bitbay.png
-      tfa: Yes
-      sms: Yes
+      tfa: No
+      sms: No
       software: Yes
-      doc: https://www.youtube.com/watch?v=KFvoNHgl9Pw
 
     - name: Bitcoin.de
       url: https://bitcoin.de


### PR DESCRIPTION
Hi guys, BitBay updated their platform and removed Rublon authentication, which was used as a Fido U2F and sms authentication platform. The only methods left are Google Authenticator or with code or email.