### PR TITLE
Update Google Play support for USB dongle auth

### DIFF
--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -28,6 +28,8 @@ websites:
       phone: Yes
       hardware: Yes
       software: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Hotstar


### PR DESCRIPTION
Now shows up as supporting OTP and U2F (Google Play login is via Google)