### PR TITLE
twitter supports u2f now

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -257,6 +257,7 @@ websites:
       sms: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
       exceptions:
           text: "SMS only available on select providers. Phone number associated with account required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -261,7 +261,7 @@ websites:
       exceptions:
           text: "SMS only available on select providers. Phone number associated with account required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes
-      doc: https://support.twitter.com/articles/20170388
+      doc: https://help.twitter.com/en/managing-your-account/two-factor-authentication
 
     - name: VanillaForums.com
       url: https://vanillaforums.com


### PR DESCRIPTION
Twitter added u2f on 2018-06-26. Mentioned here: https://twitter.com/TwitterSafety/status/1011685302635671552 and here: https://blog.twitter.com/official/en_us/topics/company/2018/how-twitter-is-fighting-spam-and-malicious-automation.html