### PR TITLE
[url] url is incorrect and redirecting to some other site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: USB Dongle Authentication
 author: Nitrokey 
 description:
     List of websites and whether or not they support One Time Passwords (OTP) or Universal 2nd Factor (U2F).
-url: https://dongleauth.org
+url: https://dongleauth.info
 repo: https://github.com/nitrokey/dongleauth
 img: img/usb_stick.png
 


### PR DESCRIPTION
The URL that is referenced here and used in Tweets is pointing to a site that is not yours.  Maybe just a mistake?

Looks to be the cause of confusion in https://github.com/Nitrokey/dongleauth/issues/169.

Fairly trivial fix; happy to do whatever testing is desired.

Cheers!