### PR TITLE
[feature] add multipleu2f

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 Contributing to DongleAuth.info 
-=======================
+===============================
 
 All the data is managed through a series of [Yaml][yaml] files so it may be
 useful to read up on the Yaml syntax.
 
-To add a new site, go to the [data files](_data/) and get familiar with how it
+To add or edit site, go to the [data files](_data/) and get familiar with how it
 is setup. There is a section and corresponding file for each Category. Site icons
 are stored in folders corresponding to each of those categories in their own
 [folder](img/).
@@ -22,7 +22,8 @@ are stored in folders corresponding to each of those categories in their own
    HTTPS address.
 4. **Alexa top 200k**: A new site, that is not already listed, has to be within the
    Alexa top 200k ranking. You can check the ranking of a site [here](https://www.alexa.com/siteinfo).
-5. **No 2FA providers**: We do not list 2FA providers, such as [Authy](https://authy.com/), [Duo](https://duo.com/) or [Google Authenticator](https://github.com/google/google-authenticator).
+5. **No 2FA providers**: We do not list 2FA providers, such as [Authy](https://authy.com/),
+[Duo](https://duo.com/) or [Google Authenticator](https://github.com/google/google-authenticator).
 6. **Be Awesome**: You need to be awesome. That is all.
 
 ## Running Locally
@@ -61,8 +62,8 @@ everything for you.
 ## Site Criteria
 
 The following section contains rough criteria and explanations regarding
-what websites should be listed on twofactorauth.org. If one of the following
-criteria is met, it belongs on twofactorauth.org:
+what websites should be listed on dongleauth.info. If one of the following
+criteria is met, it belongs on dongleauth.info:
 
 1. **Personal Info/Image**: Any site that deals with personal info or a person's
    image. An example of a site with **Personal Info** would be their Amazon
@@ -122,6 +123,7 @@ websites:
     hardware: Yes
     otp: Yes
     u2f: Yes
+    multipleu2f: No
     doc: <link to site TFA documentation>
 ```
 
@@ -133,7 +135,7 @@ If a site does provide TFA, it is strongly recommended that you add the `doc:`
 field where public documentation is available. 
 Sites supporting TFA should not have a Twitter, Facebook or Email field.
 
-The following is an example of a website that *supports* TFA:
+The following is an example of a website that *supports* TFA but not multiple dongles:
 
 ```yml
     - name: YouTube
@@ -143,6 +145,7 @@ The following is an example of a website that *supports* TFA:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: No
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
 ```
 
@@ -163,10 +166,12 @@ The following is an example of a website that *does not* support TFA:
       email_address: example@netflix.com (Only if available and monitored)
       img: netflix.png
       tfa: No
+      multipleu2f: No
       lang: <ISO 639-1 language code> (Only for non-English websites)
 ```
 
-The `lang:` field is only used for non-English websites. The language codes should be lowercase [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) codes.
+The `lang:` field is only used for non-English websites. The language codes should be
+lowercase [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) codes.
 
 ### Exceptions & Restrictions
 
@@ -246,7 +251,11 @@ website. There are 4 ways to customize how it is displayed:
 
 ## A Note on Definitions
 
-There are many forms of Two Factor Auth, but DongleAuth.info is only interested in listing sites that support Two Factor Authentication using USB dongles. Currently that means the site must support either One Time Passwords (HOTP / RFC 4226 or TOTP / RFC 6238) or FIDO Universal 2nd Factor (U2F).
+There are many forms of Two Factor Auth, but DongleAuth.info is only interested in
+listing sites that support Two Factor Authentication using USB dongles. Currently
+that means the site must support either One Time Passwords (HOTP / RFC 4226 or TOTP / RFC 6238)
+or FIDO Universal 2nd Factor (U2F). If a site supports >1 U2F dongle, `multipleu2f`
+may be set to `Yes`.
 
 A lot of people have different ideas of what constitutes Two Factor Auth and
 what doesn't, so it stands to reason that we should clarify a bit. For the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,6 @@ websites:
     hardware: Yes
     otp: Yes
     u2f: Yes
-    multipleu2f: No
     doc: <link to site TFA documentation>
 ```
 
@@ -145,7 +144,6 @@ The following is an example of a website that *supports* TFA but not multiple do
       hardware: Yes
       otp: Yes
       u2f: Yes
-      multipleu2f: No
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
 ```
 
@@ -166,7 +164,6 @@ The following is an example of a website that *does not* support TFA:
       email_address: example@netflix.com (Only if available and monitored)
       img: netflix.png
       tfa: No
-      multipleu2f: No
       lang: <ISO 639-1 language code> (Only for non-English websites)
 ```
 
@@ -254,8 +251,8 @@ website. There are 4 ways to customize how it is displayed:
 There are many forms of Two Factor Auth, but DongleAuth.info is only interested in
 listing sites that support Two Factor Authentication using USB dongles. Currently
 that means the site must support either One Time Passwords (HOTP / RFC 4226 or TOTP / RFC 6238)
-or FIDO Universal 2nd Factor (U2F). If a site supports >1 U2F dongle, `multipleu2f`
-may be set to `Yes`.
+or FIDO Universal 2nd Factor (U2F). If a site supports multiple U2F dongles (e.g. as a backup),
+`multipleu2f` may be set to `Yes`.
 
 A lot of people have different ideas of what constitutes Two Factor Auth and
 what doesn't, so it stands to reason that we should clarify a bit. For the

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,3 +1,3 @@
-TwoFactorAuth.org Blacklist
-=================
+dongleauth.info Blacklist
+=========================
 

--- a/UPSTREAM_DIFF.md
+++ b/UPSTREAM_DIFF.md
@@ -1,6 +1,8 @@
 # Main Differences to twofactorauth
 
-This list includes the main files diverting from 'upstream' twofactorauth.org. If there are changes here, look carefully, if we can adapt these easily without breaking dongleauth.info.
+This list includes the main files diverting from 'upstream' twofactorauth.org.
+If there are changes here, look carefully, if we can adapt these easily without
+breaking dongleauth.info.
 
 * \_config.yml
 * \_data/providers.yml
@@ -21,7 +23,8 @@ This list includes the main files diverting from 'upstream' twofactorauth.org. I
 
 # How to compare changes
 
-It is recommended to use the program [meld](http://meldmerge.org/) and git's mergetool to compare the dongleauth.info and twofactorauth.org step by step.
+It is recommended to use the program [meld](http://meldmerge.org/) and git's mergetool
+to compare the dongleauth.info and twofactorauth.org step by step.
 
 ```
 git clone https://github.com/Nitrokey/dongleauth.git
@@ -34,5 +37,5 @@ Be careful what to include. Especially changes in the files mentioned above shou
 care.
 
 We are able to use their changes directly, but unfortunately we can not push ours directly upstream.
-Thus, every 'otp' and 'u2f' should be kept when comparing. Sites deleted on twofactorauth.org may be
-deleted on dongleauth.info as well.
+Thus, every `otp`, `u2f`, and `multipleu2f` should be kept when comparing. Sites deleted on
+twofactorauth.org may be deleted on dongleauth.info as well.

--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -64,6 +64,7 @@ websites:
     hardware: Yes
     otp: Yes
     u2f: Yes
+    multipleu2f: Yes
     doc: https://www.dropbox.com/en/help/363
 
   - name: Evernote

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -8,7 +8,6 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
-      multipleu2f: No
       doc: https://aws.amazon.com/iam/details/mfa/
 
     - name: appFog

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -8,6 +8,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: No
       doc: https://aws.amazon.com/iam/details/mfa/
 
     - name: appFog
@@ -74,6 +75,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Heroku

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -34,6 +34,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: GMX

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -259,7 +259,6 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
-      multipleu2f: No
       exceptions:
           text: "SMS only available on select providers. Phone number associated with account required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -259,6 +259,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: No
       exceptions:
           text: "SMS only available on select providers. Phone number associated with account required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -16,7 +16,6 @@
       -->
       <th class="two wide">One Time Passwords (OTP)</th>
       <th class="two wide">Universal 2nd Factor (U2F)</th>
-      <th class="two wide">Multiple Dongle Support (>1)</th>
     </tr>
     </thead>
     <tbody class="jets-content">
@@ -96,11 +95,8 @@
           {% if website.u2f %}
           <i class="checkmark large icon" title="Universal 2nd Factor (U2F)"></i>
           {% endif %}
-        </td>
-
-        <td class="positive icon">
           {% if website.multipleu2f %}
-          <i class="checkmark large icon" title="Multiple Dongle Support (>1)"></i>
+          <i class="clone large icon" title="Multiple Dongle Support (>1)"></i>
           {% endif %}
         </td>
       {% else %}

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -7,13 +7,16 @@
     <tr>
       <th class="single line four wide"><h3>{{ section_title }}</h3></th>
       <th class="two wide">Docs</th>
-<!--      <th class="two wide">SMS</th>
+      <!--
+      <th class="two wide">SMS</th>
       <th class="two wide">Phone Call</th>
       <th class="two wide">Email</th>
       <th class="two wide">Hardware Token</th>
-      <th class="two wide">Software Token</th>-->
+      <th class="two wide">Software Token</th>
+      -->
       <th class="two wide">One Time Passwords (OTP)</th>
       <th class="two wide">Universal 2nd Factor (U2F)</th>
+      <th class="two wide">Multiple Dongle Support (>1)</th>
     </tr>
     </thead>
     <tbody class="jets-content">
@@ -51,7 +54,8 @@
           {% endif %}
         </td>
 
-<!--        <td class="positive icon">
+        <!--
+        <td class="positive icon">
           {% if website.sms %}
           <i class="checkmark large icon" title="SMS"></i>
           {% endif %}
@@ -79,7 +83,8 @@
           {% if website.software %}
           <i class="checkmark large icon" title="Software Token"></i>
           {% endif %}
-        </td>-->
+        </td>
+        -->
 
         <td class="positive icon">
           {% if website.otp %}
@@ -90,6 +95,12 @@
         <td class="positive icon">
           {% if website.u2f %}
           <i class="checkmark large icon" title="Universal 2nd Factor (U2F)"></i>
+          {% endif %}
+        </td>
+
+        <td class="positive icon">
+          {% if website.multipleu2f %}
+          <i class="checkmark large icon" title="Multiple Dongle Support (>1)"></i>
           {% endif %}
         </td>
       {% else %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -34,9 +34,9 @@
         {% endif %}
         {% if website.u2f %}
           <p><i class="checkmark small icon" title="U2F"></i> Universal 2nd Factor (U2F)</p>
-          {% if website.multipleu2f %}
-            <p><i class="clone small icon" title="Multiple U2F"></i> Multiple Dongle Support (>1)</p>
-          {% endif %}
+        {% if website.multipleu2f %}
+          <p><i class="clone small icon" title="Multiple U2F"></i> Multiple Dongle Support (>1)</p>
+        {% endif %}
         {% endif %}
       </div>
       {% if website.doc %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -31,6 +31,7 @@
       <div class="methods">
         {% if website.otp %}<p><i class="checkmark small icon" title="OTP"></i> One Time Passwords (OTP)</p>{% endif %}
         {% if website.u2f %}<p><i class="checkmark small icon" title="U2F"></i> Universal 2nd Factor (U2F)</p>{% endif %}
+        {% if website.multipleu2f %}<p><i class="checkmark small icon" title="Multiple U2F"></i> Multiple Dongle Support (>1)</p>{% endif %}
       </div>
       {% if website.doc %}
       <div class="button-group">

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -29,9 +29,15 @@
     <div class="main positive">
       {% include row-title.html section=section_id website=website type='mobile' %}
       <div class="methods">
-        {% if website.otp %}<p><i class="checkmark small icon" title="OTP"></i> One Time Passwords (OTP)</p>{% endif %}
-        {% if website.u2f %}<p><i class="checkmark small icon" title="U2F"></i> Universal 2nd Factor (U2F)</p>{% endif %}
-        {% if website.multipleu2f %}<p><i class="checkmark small icon" title="Multiple U2F"></i> Multiple Dongle Support (>1)</p>{% endif %}
+        {% if website.otp %}
+          <p><i class="checkmark small icon" title="OTP"></i> One Time Passwords (OTP)</p>
+        {% endif %}
+        {% if website.u2f %}
+          <p><i class="checkmark small icon" title="U2F"></i> Universal 2nd Factor (U2F)</p>
+          {% if website.multipleu2f %}
+            <p><i class="clone small icon" title="Multiple U2F"></i> Multiple Dongle Support (>1)</p>
+          {% endif %}
+        {% endif %}
       </div>
       {% if website.doc %}
       <div class="button-group">

--- a/websites_schema.yml
+++ b/websites_schema.yml
@@ -34,6 +34,9 @@ mapping:
           "u2f":
             type: bool
             pattern: /true/
+          "multipleu2f":
+            type: bool
+            pattern: /true/
           "sms":
             type: bool
             pattern: /true/


### PR DESCRIPTION
Adds a new feature for display of multiple U2F support per site.

The idea being to show sites that do/do not support multiple dongles.  For example, AWS and Twitter do not support multiple dongles and other sites such as Dropbox and Google do.

As this is a new feature and we haven't discussed it before, feel free to drop if this isn't something you think would be a good addition to your fork.  No worries from my side.  :)

I did some minor formatting cleanup as I was making changes to the various `README` files.

If you think this would be valuable happy to iterate on any feedback to get it shipped.

Couple screenshots from local serving-

Showing new column with GCP checkmark:
![screen shot 2019-01-06 at 12 10 12 pm](https://user-images.githubusercontent.com/333037/50741056-0b69ac80-11ad-11e9-9790-7df310f80093.png)

Similar for Gmail:
![screen shot 2019-01-06 at 12 10 38 pm](https://user-images.githubusercontent.com/333037/50741058-0e649d00-11ad-11e9-98c9-fbe4d68331e3.png)

Showing new column with a `No` value for Twitter:
![screen shot 2019-01-06 at 12 10 55 pm](https://user-images.githubusercontent.com/333037/50741060-115f8d80-11ad-11e9-8a16-c031a6120afb.png)

The local tests look to be complaining about the `tfa` value which I didn't touch:
```
$ bundle exec rake
Configuration file: ./_config.yml
            Source: ./
       Destination: ./_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 3.021 seconds.
Running ["HtmlCheck", "LinkCheck", "ImageCheck", "ScriptCheck"] on ["./_site"] on *.html... 


Ran on 9 files!


HTML-Proofer finished successfully.
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby ./verify.rb
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
<------------ ERROR ------------>
1. Amazon Web Services: 'false': not matched to pattern /true/.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
'email_address' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
2. Twitter: 'false': not matched to pattern /true/.
'twitter' should NOT be present when tfa: true.
'facebook' should NOT be present when tfa: true.
rake aborted!
```

Cheers-