### PR TITLE
mail.de supports Authenticator + U2F

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -75,6 +75,9 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
       doc: https://mail.de/hilfe/u2f-authenticator
 
     - name: Mail.Ru


### PR DESCRIPTION
Authenticator OTP since 2012, U2F since 2016. Multiple U2F devices can be registered. U2F via new webauthn API (Chrome, Firefox, Opera and Edge can use it natively without Addons).