### PR TITLE
Updated 1Password entry, as it now supports U2F

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -6,8 +6,10 @@ websites:
       software: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
       exceptions:
-        text: "1Password advertises hardware 2FA on Yubikey but it's just software TOTP. Teams using Duo with 1Password can't enable additional 2FA as it's already handled by Duo"
+        text: "Teams using Duo with 1Password can't enable additional 2FA as it's already handled by Duo"
       doc: https://support.1password.com/two-factor-authentication/
 
     - name: Bitium


### PR DESCRIPTION
In the last few days, 1Password released support for U2F security keys.

Their post about it is here: https://support.1password.com/security-key/

The originally linked doc was updated with a link to the one above.