### PR TITLE
DigitalOcean supports OTPs

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -46,6 +46,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.digitalocean.com/docs/accounts/security/2fa/
 
     - name: EngineYard


### PR DESCRIPTION
Fixes #184.

https://www.digitalocean.com/docs/accounts/security/2fa/#using-an-app-preferred