### PR TITLE
PayPal now supports standard TOTP

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -111,9 +111,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
-      exceptions:
-          text: "2FA is only available in a few countries. Contact PayPal on twitter for an up to date list of available countries."
-      doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
+      otp: Yes
+      doc: https://www.paypal.com/us/smarthelp/article/what-is-2-step-verification-faq4057
 
     - name: Paysafecard
       url: https://www.paysafecard.com/


### PR DESCRIPTION
PayPal has recently added support for standard TOTP authentication.  The help page https://www.paypal.com/us/smarthelp/article/what-is-2-step-verification-faq4057 is available for a variety of other countries e.g.:
* https://www.paypal.com/uk/smarthelp/article/what-is-2-step-verification-faq4057
* https://www.paypal.com/de/smarthelp/article/what-is-2-step-verification-faq4057
* https://www.paypal.com/fr/smarthelp/article/what-is-2-step-verification-faq4057
* https://www.paypal.com/es/smarthelp/article/what-is-2-step-verification-faq4057
* https://www.paypal.com/ru/smarthelp/article/what-is-2-step-verification-faq4057
* etc

This suggests that the feature is now available for many (if not all) countries.