### PR TITLE
Facebook supports multiple U2F devices

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -75,6 +75,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       doc: https://www.facebook.com/help/148233965247823
 
     - name: Flipboard


### PR DESCRIPTION
I don't believe that Facebook's 2FA help pages explicitly mention that multiple U2F devices are supported, but this is the 'security key' section of my account with two devices registered:

![Via security key dialog](https://user-images.githubusercontent.com/961548/60543490-56a0ea00-9d0e-11e9-9912-eb9444be5049.png)