### PR TITLE
Andrews & Arnold support OTP

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -11,6 +11,7 @@ websites:
       img: aaisp.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       otp: Yes
       doc: https://aa.net.uk/kb-broadband-2fa.html
       exceptions:

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -11,6 +11,7 @@ websites:
       img: aaisp.png
       tfa: Yes
       software: Yes
+      otp: Yes
       doc: https://aa.net.uk/kb-broadband-2fa.html
       exceptions:
           text: "While both the accounts and control web pages support 2FA, each system is separate and requires its own setup."


### PR DESCRIPTION
Andrews & Arnold support TOTP - unfortunately as part of their recent website redesign, the 2FA documentation page currently redirects to a page which doesn't seem to contain any 2FA information, but the [version from just before the redesign](https://web.archive.org/web/20190330144640/https://aa.net.uk/kb-broadband-2fa.html) mentions TOTP explicitly.