### PR TITLE
Namecheap supports multiple U2F devices

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -364,6 +364,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       doc: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication
 
     - name: NameSilo.com


### PR DESCRIPTION
Namecheap supports registering multiple U2F devices against an account:
https://www.namecheap.com/support/knowledgebase/article.aspx/10102/45/how-can-i-use-the-u2f-method-for-twofactor-authentication#newdevice