### PR TITLE
Update Braintree Payments hardware support

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -15,6 +15,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       otp: Yes
       doc: https://articles.braintreepayments.com/reference/security/two-factor-authentication
 


### PR DESCRIPTION
Braintree now support Webauthn Hardware 2FA as of August 2019.