### PR TITLE
Nominet supports TOTP

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -431,6 +431,7 @@ websites:
       img: nominet.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       otp: Yes
       doc: https://registrars.nominet.org.uk/sites/default/files/two_factor_authentication_userguide.pdf
 

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -431,6 +431,7 @@ websites:
       img: nominet.png
       tfa: Yes
       software: Yes
+      otp: Yes
       doc: https://registrars.nominet.org.uk/sites/default/files/two_factor_authentication_userguide.pdf
 
     - name: NS1


### PR DESCRIPTION
Nominet supports TOTP for 2FA:
https://media.nominet.uk/wp-content/uploads/2015/10/Two_Factor_Authentication_USER_GUIDE_Jan_2015.pdf