### PR TITLE
Ubiquiti supports TOTP as their second factor

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -569,6 +569,8 @@ websites:
       img: ubiquiti.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.ubnt.com/hc/en-us/articles/115012986607
 
     - name: Ulule


### PR DESCRIPTION
Ubiquiti support TOTP as their second factor for account authentication.