### PR TITLE
Realme supports TOTP (documented as Google Auth)

### DIFF
--- a/_data/government.yml
+++ b/_data/government.yml
@@ -92,6 +92,7 @@ websites:
       sms: Yes
       hardware: Yes
       software: Yes
+      otp: Yes
       doc: https://www.realme.govt.nz/help/#second-factor-authentication
 
     - name: Skatteverket


### PR DESCRIPTION
Realme docs say it supports Google Auth and provides the key necessary to add to any TOTP compliant authenticator