### PR TITLE
Remove hardware OTP claim for Apple

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -43,12 +43,15 @@ websites:
     - name: Apple
       url: https://appleid.apple.com
       img: apple.png
+      twitter: applesupport
       tfa: Yes
       sms: Yes
       phone: Yes
       software: Yes
-      hardware: Yes
-      otp: Yes
+      hardware: No
+      otp: No
+      exceptions:
+          text: "SMS or Apple device 2FA only. No third party authenticator support"
       doc: https://support.apple.com/en-us/HT204915
 
     - name: Arcaplanet

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -48,7 +48,6 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
-      hardware: No
       otp: No
       exceptions:
           text: "SMS or Apple device 2FA only. No third party authenticator support"


### PR DESCRIPTION
Apple has no RFC based 2fa - can only 2fa with Apple device or SMS.