### PR TITLE
Patch apple - remove non-RFC 2fa

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -43,12 +43,15 @@ websites:
     - name: Apple
       url: https://appleid.apple.com
       img: apple.png
+      twitter: applesupport
       tfa: Yes
       sms: Yes
       phone: Yes
       software: Yes
-      hardware: Yes
-      otp: Yes
+      hardware: No
+      otp: No
+      exceptions:
+          text: "SMS or Apple device 2FA only. No third party authenticator support"
       doc: https://support.apple.com/en-us/HT204915
 
     - name: Arcaplanet

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -48,7 +48,6 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
-      hardware: No
       otp: No
       exceptions:
           text: "SMS or Apple device 2FA only. No third party authenticator support"

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -48,7 +48,6 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
-      otp: No
       exceptions:
           text: "SMS or Apple device 2FA only. No third party authenticator support"
       doc: https://support.apple.com/en-us/HT204915


### PR DESCRIPTION
From docs: site must support either One Time Passwords (HOTP / RFC 4226 or TOTP / RFC 6238) or FIDO Universal 2nd Factor (U2F)

Apple uses non-RFC 2FA which requires Apple device or SMS