### PR TITLE
Add U2F support to LastPass

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -102,6 +102,8 @@ websites:
       software: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
       doc: https://helpdesk.lastpass.com/multifactor-authentication-options/
 
     - name: MyDigipass.com


### PR DESCRIPTION
LastPass supports U2F. Their documentation[1] does not explicitly
mention U2F, Fido, or Webauthn, but they do mention the YubiKey 5.
More to the point, I use two YubiKey 5Cs on my own personal account
and it works with Firefox on Linux and on Android.

 [1] https://support.logmeininc.com/lastpass/help/yubikey-multifactor-authentication-lp030020

Signed-off-by: Eduardo Santiago <ed@edsantiago.com>