### PR TITLE
Add info on Bitwarden multiple U2F keys support

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -32,6 +32,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       exceptions:
         text: "Premium account required for Duo, YubiKey and FIDO U2F."
       doc: https://help.bitwarden.com/article/setup-two-step-login/


### PR DESCRIPTION
Bitwarden supports multiple U2F keys

(As I have exeperience personally, and as can be seen on [screenshots](https://bitwarden.com/help/images/two-step/u2f/config.png) in their [documentation](https://bitwarden.com/help/article/setup-two-step-login-u2f/))