### PR TITLE
Mark Yahoo accounts as supporting U2F.

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -282,6 +282,10 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
+      u2f: Yes
+      multipleu2f: No
+      exceptions:
+          text: "Only one security key per account is currently supported"
       doc: https://help.yahoo.com/kb/SLN5013.html
 
     - name: Yandex.Mail


### PR DESCRIPTION
Yahoo seems to be starting to support security keys ([source](https://www.reddit.com/r/yubikey/comments/i4qrdn/security_key_support_now_at_yahoo/). This pull request marks them as supporting keys. I can't find a doc reference for this, unfortunately, but I set it up myself and it does work.