### PR TITLE
Update ID.me data with full support

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -67,7 +67,11 @@ websites:
       software: Yes
       hardware: Yes
       phone: Yes
-      doc: https://help.id.me/hc/en-us/categories/360001435974
+      u2f: Yes
+      otp: Yes
+      sms: Yes
+      multipleu2f: Yes
+      doc: https://help.id.me/hc/en-us/articles/360017969214
 
     - name: IDentité Numérique (IDN)
       url: https://www.idn.laposte.fr

--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -69,7 +69,6 @@ websites:
       phone: Yes
       u2f: Yes
       otp: Yes
-      sms: Yes
       multipleu2f: Yes
       doc: https://help.id.me/hc/en-us/articles/360017969214
 


### PR DESCRIPTION
Was playing around with the new Chrome+Android FIDO2/WebAuthn caBLE support, and found that ID.me had full support for everything, but was listing as no support.