### PR TITLE
Update README.md to reflect new name of upstream project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The goal is to build a website ([dongleauth.com](https://www.dongleauth.com)) wi
 Our hope is to aid consumers who are deciding between alternative services based on the security they
 offer for their customers. This can also serve as an indicator for the effort a site has put into security in general.
 
-This site is a fork of [TwoFactorAuth](https://twofactorauth.org). The fork is necessary to further differentiate the 'Hardware' section. The TwoFactorAuth projects wants to give a general overview and do not wants to mark the technical details as well. We respect this decision. In need of a differentiation between OTP and U2F we decided to fork the project. Please see [the note on definitions](https://github.com/Nitrokey/dongleauth/blob/device_authenticators/CONTRIBUTING.md#a-note-on-definitions) as well.
+This site is a fork of [2FA Directory](https://2fa.directory). The fork is necessary to further differentiate the 'Hardware' section. The 2FA Directory project wants to give a general overview and do not wants to mark the technical details as well. We respect this decision. In need of a differentiation between OTP and U2F we decided to fork the project. Please see [the note on definitions](https://github.com/Nitrokey/dongleauth/blob/device_authenticators/CONTRIBUTING.md#a-note-on-definitions) as well.
 
 ## Contributing
 


### PR DESCRIPTION
The upstream project is at a new domain and is now called 2fa.directory. The previous link in the readme now goes to an unrelated website.