### PR TITLE
Re-enable Metrics/AbcSize

### DIFF
--- a/verify.rb
+++ b/verify.rb
@@ -47,7 +47,6 @@ def test_img(img, name, imgs)
   test_img_file(img)
 end
 
-# rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
 def test_img_file(img)
   # Check image file extension and type
@@ -70,7 +69,6 @@ def test_img_file(img)
   end
   # rubocop:enable Style/GuardClause
 end
-# rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/MethodLength
 
 # Load each section, check for errors such as invalid syntax


### PR DESCRIPTION
Currently, the build fails with this robocop error:

```
verify.rb:50:1: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/AbcSize.
```

This patch attempts to fix this by re-enabling the Metrics/AbcSize lint in verify.rb.