### PR TITLE
Update Vanguard to reflect removal of restrictions

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -193,8 +193,7 @@ websites:
       phone: Yes
       hardware: Yes
       u2f: Yes
-      exceptions:
-        text: "Hardware 2FA requires using a Chrome browser and only supports the following hardware keys: Yubikey 4 Series, YubiKey 5 Series, Yubikey Security Key Series."
+      multipleu2f: Yes
       doc: https://investor.vanguard.com/security/security-keys
 
     - name: Wealthfront


### PR DESCRIPTION
Vanguard now supports all FIDO2 keys (tested with Solo keys), all browsers (tested with Firefox), and registering multiple keys.