### PR TITLE
Proton mail and Proton VPN Updates

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -184,6 +184,8 @@ websites:
       software: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
       doc: https://protonmail.com/support/knowledge-base/two-factor-authentication/
 
     - name: Riseup Mail

--- a/_data/vpn.yml
+++ b/_data/vpn.yml
@@ -79,6 +79,8 @@ websites:
       img: protonvpn.png
       tfa: Yes
       software: Yes
+      otp: Yes
+      doc: https://protonvpn.com/support/two-factor-authentication/
 
     - name: PureVPN
       url: https://www.purevpn.com


### PR DESCRIPTION
Proton Mail now supports u2f with multiple keys.  Proton VPN supports TOTP (link to documentation included).