### PR TITLE
Update Request #316: charles schwab OTP 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ group :test do
   gem 'rake'
   gem 'rubocop'
 end
+
+gem "webrick", "~> 1.7"

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -315,4 +315,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      doc: https://adminconsole.wiki.zoho.com/mail/Two-Factor-Authentication.html
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: https://help.zoho.com/portal/en/kb/accounts/multi-factor-authentication

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -28,7 +28,8 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: /notes/schwab/
+      otp: Yes
+      doc: https://www.schwab.com/help/two-factor-authentication
 
     - name: COL Financial
       url: https://www.colfinancial.com

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -26,6 +26,7 @@ websites:
       url: https://www.schwab.com/
       img: charlesschwab.png
       tfa: Yes
+      sms: Yes
       software: Yes
       hardware: Yes
       otp: Yes


### PR DESCRIPTION
Charles Schwab now has OTP as referenced in the link below 

https://www.schwab.com/help/two-factor-authentication

Added otp and new link 