### PR TITLE
Update Request ISSUE #316:Schwab supports OTP

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -28,7 +28,8 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: /notes/schwab/
+      otp: Yes
+      doc: https://www.schwab.com/help/two-factor-authentication
 
     - name: COL Financial
       url: https://www.colfinancial.com


### PR DESCRIPTION
Schwab supports 2FA as suggested in the link below
https://www.schwab.com/help/two-factor-authentication