### PR TITLE
Update Braintree listing to add multiple WebAuthn support

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -17,6 +17,8 @@ websites:
       software: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
       doc: https://articles.braintreepayments.com/reference/security/two-factor-authentication
 
     - name: Buycraft


### PR DESCRIPTION
Braintree supports WebAuthn, and it supports multiple keys. I updated the listing with:

      u2f: Yes
      multipleu2f: Yes