### PR TITLE
Update OVH listing to add multiple WebAuthn key support

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -407,6 +407,7 @@ websites:
       software: Yes
       hardware: Yes
       u2f: Yes
+      multipleu2f: Yes
       otp: Yes
 
     - name: PlanetHoster

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -409,6 +409,7 @@ websites:
       u2f: Yes
       multipleu2f: Yes
       otp: Yes
+      doc: https://docs.ovh.com/us/en/private-cloud/use-2FA/
 
     - name: PlanetHoster
       url: https://www.planethoster.com/

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -409,7 +409,7 @@ websites:
       u2f: Yes
       multipleu2f: Yes
       otp: Yes
-      doc: https://docs.ovh.com/us/en/private-cloud/use-2FA/
+      doc: https://support.us.ovhcloud.com/hc/en-us/articles/115001825710-How-to-Use-Two-Factor-Authentication
 
     - name: PlanetHoster
       url: https://www.planethoster.com/


### PR DESCRIPTION
OVH supports multiple security keys, so I added `multipleu2f: Yes` to the listing.