### PR TITLE
Issue #331 Updated Entries

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -177,6 +177,9 @@ websites:
     software: Yes
     hardware: Yes
     otp: Yes
+    u2f: Yes
+    multipleu2f: Yes
+    passwordless: Yes
     exceptions:
         text: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above using Edge browser."
     doc: https://support.microsoft.com/en-us/help/12408/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -181,6 +181,7 @@ websites:
       img: crowdin.png
       tfa: Yes
       software: Yes
+      otp: Yes
       doc: https://support.crowdin.com/account-settings/#two-factor-authentication
 
     - name: Deploybot

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -155,6 +155,9 @@ websites:
       software: Yes
       hardware: Yes
       otp: Yes
+      u2f: Yes
+      multipleu2f: Yes
+      passwordless: Yes
       exceptions:
           text: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above using Edge browser."
       doc: https://support.microsoft.com/en-us/help/12408/

--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -199,7 +199,9 @@ websites:
       twitter: Vimeo
       facebook: Vimeo
       img: vimeo.png
-      tfa: No
+      tfa: Yes
+      otp: Yes
+      doc: https://vimeo.zendesk.com/hc/en-us/articles/4856243815693-Secure-your-account-with-two-factor-authentication
 
     - name: YouTube
       url: https://www.youtube.com/

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -246,6 +246,7 @@ websites:
       img: firefox.png
       tfa: Yes
       software: Yes
+      otp: Yes
       doc: https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication
 
     - name: Fiverr

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -295,7 +295,8 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
-      doc: https://ayuda.mercadolibre.com.ar/ayuda/Consejos-para-fortalecer-la-se_961
+      otp: Yes
+      doc: https://www.mercadolibre.com.ar/ayuda/Fortalecer-la-seguridad-de-mi-cuenta_945
 
     - name: Newegg
       url: https://www.newegg.com

--- a/_data/software.yml
+++ b/_data/software.yml
@@ -80,6 +80,9 @@ websites:
     software: Yes
     hardware: Yes
     otp: Yes
+    u2f: Yes
+    multipleu2f: Yes
+    passwordless: Yes
     doc: https://docs.framasoft.org/en/mastodon/User-guide.html#two-factor-authentication
 
   - name: Nextcloud


### PR DESCRIPTION
Issue #331 Updated Entries to the following

accounts.firefox.com (supports OTP)
Crowdin (supports OTP)
MercadoLibre / Mercado Libre / Mercado Pago (supports OTP)
Outlook.com / OneDrive (now it also supports WebAuthn, FIDO2, U2F and multiple dongles)
Mastodon (now it also supports WebAuthn, FIDO2, U2F and multiple dongles)
Vimeo (supports OTP)