### PR TITLE
AWS supports multiple MFA/U2F

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -8,6 +8,7 @@ websites:
       hardware: Yes
       otp: Yes
       u2f: Yes
+      multipleu2f: Yes
       doc: https://aws.amazon.com/iam/details/mfa/
 
     - name: appFog


### PR DESCRIPTION
AWS added multiple MFA (including multiple U2F) support last year.

Relevant post: https://aws.amazon.com/blogs/security/you-can-now-assign-multiple-mfa-devices-in-iam/